### PR TITLE
Remove deprecated github runner.

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04,ubuntu-24.04]
     steps:
     - name: Checkout git repo
       uses: actions/checkout@v4


### PR DESCRIPTION
Ubuntu 20.04 is deprecated and needs replaced. I added a second runner to run the latest ubuntu (24.04) instead.