### PR TITLE
Set runners to latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           fail_on_unmatched_files: false
 
   release-linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions: { contents: write }
     steps:
       - uses: actions/checkout@v4
@@ -73,7 +73,7 @@ jobs:
           fail_on_unmatched_files: false
 
   release-macos:
-    runs-on: macos-12
+    runs-on: macos-latest
     permissions: { contents: write }
     steps:
       - run: brew install cmake ninja gcc p7zip


### PR DESCRIPTION
The mac release was hard-coded to a now deprecated version. For release it might make more sense to use the latest runner always, its maybe expected that development builds can be tested on specific agent versions for legacy reasons but release presumably should be kept aligned with the latest agents? Otherwise another build tool might be a benefit such as vagrant.