### PR TITLE
Fix type formats causing test failures.

### DIFF
--- a/compiler/src/builtins/builtins.cpp
+++ b/compiler/src/builtins/builtins.cpp
@@ -874,7 +874,14 @@ struct builtin_cast : builtin {
            << ")yk__bstr_get_reference(" << args[1].first << "))";
     } else if (out_dt->const_unwrap()->is_a_string() && args[1].second.datatype_->const_unwrap()->is_an_integer()) {
       // Integer to string conversion
-      const char* format = (args[1].second.datatype_->const_unwrap()->is_i64() || args[1].second.datatype_->const_unwrap()->is_u64()) ? "%lld" : "%d";
+      const char* format;
+      if (args[1].second.datatype_->const_unwrap()->is_u64()) {
+        format = "%llu";
+      } else if (args[1].second.datatype_->const_unwrap()->is_i64()) {
+        format = "%lld";
+      } else {
+        format = "%d";
+      }
       code << "yk__sdscatprintf(yk__sdsempty(), \"" << format << "\", " << args[1].first << ")";
     } else {
       code << "(("

--- a/compiler/src/builtins/builtins.cpp
+++ b/compiler/src/builtins/builtins.cpp
@@ -872,6 +872,10 @@ struct builtin_cast : builtin {
       code << "(("
            << dt_compiler->convert_dt(out_dt, datatype_location::CAST, "", "")
            << ")yk__bstr_get_reference(" << args[1].first << "))";
+    } else if (out_dt->const_unwrap()->is_a_string() && args[1].second.datatype_->const_unwrap()->is_an_integer()) {
+      // Integer to string conversion
+      const char* format = (args[1].second.datatype_->const_unwrap()->is_i64() || args[1].second.datatype_->const_unwrap()->is_u64()) ? "%lld" : "%d";
+      code << "yk__sdscatprintf(yk__sdsempty(), \"" << format << "\", " << args[1].first << ")";
     } else {
       code << "(("
            << dt_compiler->convert_dt(out_dt, datatype_location::CAST, "", "")


### PR DESCRIPTION
The cast builtin was incorrectly using %lld format for both i64 and u64 types when converting integers to strings. This caused test failures as %lld is for signed long long, while %llu should be used for unsigned long long (u64).

This builds ontop of the fix for the bug causing you to not be able to print out cast values.